### PR TITLE
Update name of license

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "array"
   ],
   "author": "Mike Pennisi",
-  "license": "MIT Expat",
+  "license": "MIT",
   "devDependencies": {
     "tape": "~1.0.4"
   },


### PR DESCRIPTION
"MIT expat", while correct, trips up some automatic license scanning tools that might then block this for certain kinds of deployments. I've been caught up by this one today and I'm probably not the only one (this package is a dependency for quite a few others).


If possible, could you also make a patch-level release to get this into NPM? 